### PR TITLE
Fix Book Selection - Always Start at Top When Selecting from Sidebar

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -853,8 +853,11 @@ class BooksLibrary {
         
         if (bookId) {
             url.searchParams.set('book', bookId);
+            // Clear hash when switching books to ensure we start at the top
+            url.hash = '';
         } else {
             url.searchParams.delete('book');
+            url.hash = '';
         }
         
         window.history.pushState({ bookId }, '', url);


### PR DESCRIPTION
- Modified updateUrl() to clear hash fragments when switching books
- Ensures clicking a book in the left sidebar always takes you to the top
- Hash fragments are only preserved when navigating within the same book
- Maintains proper TOC navigation while fixing sidebar book selection

🤖 Generated with [Claude Code](https://claude.ai/code)